### PR TITLE
Improved batch inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ florence-tool run [OPTIONS]
 - `--overwrite`: Flag to overwrite existing files. If not specified, appends/updates the files.
 - `--image-extensions`: Comma-separated list of image file extensions to include (e.g., `"jpg,png,jpeg"`). Default is `"jpg,png"`.
 - `--batch-size`: Number of images to process in a batch. Default is `1`.
+- `--num-workers`: Number of Dataloader workers. Default is `4`, overriden to `0` on Windows.
 
 ### Examples
 

--- a/src/florence_tool/cli.py
+++ b/src/florence_tool/cli.py
@@ -86,6 +86,7 @@ def cli():
     help="Comma-separated list of image file extensions to include, e.g., 'jpg,png,jpeg'.",
 )
 @click.option("--batch-size", type=int, default=1, help="Batch size.")
+@click.option("--num-workers", type=int, default=4, help="Dataloader workers.")
 def run(
     hf_hub_or_path: str,
     device: str,
@@ -103,6 +104,7 @@ def run(
     overwrite: bool,
     image_extensions: str,
     batch_size: int,
+    num_workers: int,
 ):
     from florence_tool import FlorenceTool
 
@@ -140,6 +142,7 @@ def run(
             overwrite=overwrite,
             image_extensions=extensions,
             batch_size=batch_size,
+            num_workers=num_workers,
         )
         click.echo(
             f"Processed images in folder {folder}. Results saved to {output_dir}."


### PR DESCRIPTION
Processing text and image inputs for each batch causes GPU usage in current `run` method to fluctuate.

This PR aims to improve batch inference by using PyTorch `Dataset` and `DataLoader`.

Preliminary tests show a +30% improvement in GPU utilization. Tests were conducted in a Windows environment; `DataLoader` on Windows is limited to 1 worker, in a Linux environment GPU utilization should approach 100%.

Further tests will be conducted as `batch_decode` and `post_process_generation` may also be a factor.

## Todo

- [x] Currently saving with improved batch inference path is done at the end of the batch, this is likely a problem for very large batches. We can submit to the implemented `save_to_file` `ThreadPoolExecutor` during the batch without affecting performance.
- [x] If `batch_decode` and `post_process_generation` are a limiting factor we can implement another `ThreadPoolExecutor` for batch decoding and post-processing results.
- [x] All functionality should be thoroughly tested to ensure there are no regressions or other issues.
- [x] We can avoid repeated processing of `task_prompt` if `text_inputs` is `None` or the same `str`.

## Other included fixes

- [x] `image_path.suffix` is added to `output_file` path for cases where two files share the same `stem` with different extensions.