### PR TITLE
WebDataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ florence-tool run [OPTIONS]
 - `--task` (required): Task to run (e.g., `"<CAPTION>"`, `"<OD>"`, etc.).
 - `--image`: Path to an image file.
 - `--folder`: Path to a folder containing images.
+- `--wds`: WebDataset.
 - `--output-dir`: Directory to save the results.
 - `--text-input`: Optional text input for tasks that require it.
 - `--max-new-tokens`: Maximum number of new tokens to generate. Default is `1024`.
@@ -63,6 +64,7 @@ florence-tool run [OPTIONS]
 - `--image-extensions`: Comma-separated list of image file extensions to include (e.g., `"jpg,png,jpeg"`). Default is `"jpg,png"`.
 - `--batch-size`: Number of images to process in a batch. Default is `1`.
 - `--num-workers`: Number of Dataloader workers. Default is `4`, overriden to `0` on Windows.
+- `--image-key`: WebDataset image key.
 
 ### Examples
 
@@ -76,6 +78,22 @@ florence-tool run --hf-hub-or-path microsoft/Florence-2-large --task "<CAPTION>"
 
 ```bash
 florence-tool run --hf-hub-or-path microsoft/Florence-2-large --task "<OD>" --folder /path/to/folder/ --output-dir /path/to/output/
+```
+
+#### Processing a WebDataset
+
+```bash
+florence-tool run --hf-hub-or-path microsoft/Florence-2-large --task "<CAPTION>" --wds "shard-{00000..00069}.tar" --output-dir /path/to/output/
+```
+
+#### Processing a WebDataset (streaming)
+
+```bash
+florence-tool run --hf-hub-or-path microsoft/Florence-2-large --task "<CAPTION>" --wds "pipe:aws s3 cp s3://data/shard-{00000..00069}.tar -" --output-dir /path/to/output/
+```
+
+```bash
+florence-tool run --hf-hub-or-path microsoft/Florence-2-large --task "<CAPTION>" --wds "pipe:aws s3 cp s3://data/shard-{00000..00069}.tar --endpoint-url https://00000000000000000000000000000000.r2.cloudflarestorage.com -" --output-dir /path/to/output/
 ```
 
 #### Processing Images Recursively

--- a/src/florence_tool/cli.py
+++ b/src/florence_tool/cli.py
@@ -45,6 +45,11 @@ def cli():
     help="Path to a folder containing images.",
 )
 @click.option(
+    "--wds",
+    type=str,
+    help="WebDataset url.",
+)
+@click.option(
     "--output-dir",
     type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
     help="Directory to save the results.",
@@ -87,6 +92,7 @@ def cli():
 )
 @click.option("--batch-size", type=int, default=1, help="Batch size.")
 @click.option("--num-workers", type=int, default=4, help="Dataloader workers.")
+@click.option("--image-key", type=str, default="jpg", help="WebDataset image key.")
 def run(
     hf_hub_or_path: str,
     device: str,
@@ -94,6 +100,7 @@ def run(
     task: str,
     image: Optional[pathlib.Path],
     folder: Optional[pathlib.Path],
+    wds: Optional[str],
     output_dir: Optional[pathlib.Path],
     text_input: str,
     max_new_tokens: int,
@@ -105,6 +112,7 @@ def run(
     image_extensions: str,
     batch_size: int,
     num_workers: int,
+    image_key: str,
 ):
     from florence_tool import FlorenceTool
 
@@ -148,8 +156,26 @@ def run(
             f"Processed images in folder {folder}. Results saved to {output_dir}."
         )
 
+    elif wds:
+        tool.wds(
+            webdataset_uri=wds,
+            task=task,
+            text_input=text_input,
+            max_new_tokens=max_new_tokens,
+            num_beams=num_beams,
+            batch_size=batch_size,
+            output_format=output_format,
+            output_dir=output_dir,
+            suffix=suffix,
+            overwrite=overwrite,
+            num_workers=num_workers,
+            image_key=image_key,
+        )
+
     else:
-        click.echo("Please specify either an image file or a folder of images.")
+        click.echo(
+            "Please specify either an image file, a folder of images or WebDataset url."
+        )
 
     tool.unload_model()
 


### PR DESCRIPTION
Support WebDataset with `--wds` e.g. `--wds "shard-{00000..00069}.tar"`.

Outputs to `"{sample['__url__']}_{sample['__key__']}"` e.g. `shard-00000_00000_caption.json`.
`__url__` is processed for streaming WebDataset e.g. `pipe:aws s3 cp s3://data/shard-00000.tar --endpoint-url https://00000000000000000000000000000000.r2.cloudflarestorage.com -`, `pipe:aws s3 cp s3://data/shard-00000.tar -`:
- split by ` --` in case of endpoint-url
- split by `/`

## Testing
- [x] Local `tar` files
- [x] Streaming
- [x] Linux

Closes #2