### PR TITLE
Third Party Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ florence-tool run [OPTIONS]
 - `--num-workers`: Number of Dataloader workers. Default is `4`, overriden to `0` on Windows.
 - `--prefetch-factor`: Prefetch factor for Dataloader workers. Default is `4`.
 - `--image-key`: WebDataset image key.
+- `--no-check`: Skips task type check for models with added task types - task will be processed as the default `pure_text` type. This is intended for testing purposes, new task types can be added to the check, just create an issue or PR.
 
 ### Examples
 
@@ -151,6 +152,19 @@ florence-tool run --hf-hub-or-path microsoft/Florence-2-large --task "<CAPTION>"
 <REGION_TO_DESCRIPTION>
 <REGION_TO_OCR>
 <REGION_PROPOSAL>
+```
+
+#### Third Party Task Types
+
+Supported by [`MiaoshouAI/Florence-2-base-PromptGen-v1.5`](https://huggingface.co/MiaoshouAI/Florence-2-base-PromptGen-v1.5)
+```
+<GENERATE_TAGS>
+<MIXED_CAPTION>
+```
+
+Supported by [`MiaoshouAI/Florence-2-base-PromptGen`](https://huggingface.co/MiaoshouAI/Florence-2-base-PromptGen)
+```
+<GENERATE_PROMPT>
 ```
 
 ### Development

--- a/src/florence_tool/cli.py
+++ b/src/florence_tool/cli.py
@@ -96,6 +96,7 @@ def cli():
     "--prefetch-factor", type=int, default=4, help="Dataloader prefetch factor."
 )
 @click.option("--image-key", type=str, default="jpg", help="WebDataset image key.")
+@click.option("--no-check", is_flag=True, help="Skip task type check.")
 def run(
     hf_hub_or_path: str,
     device: str,
@@ -117,12 +118,18 @@ def run(
     num_workers: int,
     prefetch_factor: int,
     image_key: str,
+    no_check: bool,
 ):
     from florence_tool import FlorenceTool
 
     extensions = image_extensions.split(",")
 
-    tool = FlorenceTool(hf_hub_or_path=hf_hub_or_path, device=device, dtype=dtype)
+    tool = FlorenceTool(
+        hf_hub_or_path=hf_hub_or_path,
+        device=device,
+        dtype=dtype,
+        check_task_types=not no_check,
+    )
 
     tool.load_model()
 

--- a/src/florence_tool/florence_tool.py
+++ b/src/florence_tool/florence_tool.py
@@ -24,7 +24,7 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
 
-TASK_TYPES = [
+ORIGINAL_TASK_TYPES = [
     "<OCR>",
     "<OCR_WITH_REGION>",
     "<CAPTION>",
@@ -42,12 +42,23 @@ TASK_TYPES = [
     "<REGION_PROPOSAL>",
 ]
 
+THIRD_PARTY_TASK_TYPES = [
+    "<GENERATE_TAGS>",
+    "<MIXED_CAPTION>",
+    "<GENERATE_PROMPT>",
+]
+
+TASK_TYPES = ORIGINAL_TASK_TYPES + THIRD_PARTY_TASK_TYPES
+
 TASK_TYPE = Literal[
     "<OCR>",
     "<OCR_WITH_REGION>",
     "<CAPTION>",
     "<DETAILED_CAPTION>",
     "<MORE_DETAILED_CAPTION>",
+    "<GENERATE_TAGS>",
+    "<MIXED_CAPTION>",
+    "<GENERATE_PROMPT>",
     "<OD>",
     "<DENSE_REGION_CAPTION>",
     "<CAPTION_TO_PHRASE_GROUNDING>",
@@ -219,6 +230,7 @@ class FlorenceTool:
         device: Union[str, torch.device],
         dtype: Union[str, torch.dtype],
         max_workers: int = 8,
+        check_task_types: bool = True,
     ) -> None:
         self.set_device(device)
         self.set_dtype(dtype)
@@ -231,6 +243,7 @@ class FlorenceTool:
         self.post_process_futures: List[Future] = []
         self.dataloader = None
         self.dataset = None
+        self.check_task_types = check_task_types
         logging.info(
             f"Initialized\n- hf_hub_or_path: {self.hf_hub_or_path}\n- device: {self.device}\n- dtype: {self.dtype}"
         )
@@ -387,9 +400,10 @@ class FlorenceTool:
         if self.model is None or self.processor is None:
             logging.error("Call `load_model` before `run`.")
             return
-        assert (
-            task_prompt in TASK_TYPES
-        ), f"{task_prompt} is not supported. Expected one of {TASK_TYPES}."
+        if self.check_task_types:
+            assert (
+                task_prompt in TASK_TYPES
+            ), f"{task_prompt} is not supported. Expected one of {TASK_TYPES}."
 
         if isinstance(images, Image.Image):
             images = [images]
@@ -451,9 +465,10 @@ class FlorenceTool:
         if self.model is None or self.processor is None:
             logging.error("Call `load_model` before `run`.")
             return
-        assert (
-            task_prompt in TASK_TYPES
-        ), f"{task_prompt} is not supported. Expected one of {TASK_TYPES}."
+        if self.check_task_types:
+            assert (
+                task_prompt in TASK_TYPES
+            ), f"{task_prompt} is not supported. Expected one of {TASK_TYPES}."
 
         prompt = task_prompt
         if text_input is not None:


### PR DESCRIPTION
Add third party tasks from [`MiaoshouAI/Florence-2-base-PromptGen-v1.5`](https://huggingface.co/MiaoshouAI/Florence-2-base-PromptGen-v1.5) and [`MiaoshouAI/Florence-2-base-PromptGen`](https://huggingface.co/MiaoshouAI/Florence-2-base-PromptGen) to type checker, document the task types and add a `--no-check` option to enable testing of future third party tasks before they are added to the type checker.